### PR TITLE
Added support for links for the form [[link|text]]

### DIFF
--- a/lua/jot/command.lua
+++ b/lua/jot/command.lua
@@ -46,7 +46,7 @@ local goto_file = function(state, data)
     -- Create a note with the given name inside of the current 
     -- directory
     local current_directory = vim.fn.expand('%:h')
-    local note_name = link_under_cursor.text
+    local note_name = link_under_cursor.link
 
     linked_note = Note.from_dir_and_name(current_directory, note_name)
   end


### PR DESCRIPTION
### Feature

Now you can create notes of the form `[[link|text]]`. `:JotJump` will bring you to `link.md` and the link will only display "text".

### Example
<img width="108" alt="image" src="https://user-images.githubusercontent.com/45083086/196587025-606b85be-8bae-45c3-9db9-6412b30db59a.png">
<img width="40" alt="image" src="https://user-images.githubusercontent.com/45083086/196587060-996133f7-5272-46dd-97d5-fa5b8d2a06f7.png">
